### PR TITLE
Fix greyed out icon on Chrome

### DIFF
--- a/extension_base/source/chrome/manifest.json
+++ b/extension_base/source/chrome/manifest.json
@@ -12,6 +12,7 @@
 		}
 	],
 	"icons": {
-          "128": "icon128.png" }
-
+          "128": "icon128.png" },
+        "browser_action": {
+    	  "default_icon": "icon128.png"}
 }


### PR DESCRIPTION
Fix as per http://stackoverflow.com/questions/36049472/why-is-my-chrome-extension-grayed-out
